### PR TITLE
feat: improve docker test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,9 +144,11 @@ container-test-all:
 		echo "Container not running, starting it first..."; \
 		./docker-test/run.sh; \
 	fi
-	@echo "Rebuilding project before testing..."
-	@docker exec -it minirt-valgrind-test bash -c "make re"
-	@./docker-test/test_all.sh
+       @echo "Rebuilding project before testing..."
+       @# Use -it when a TTY is available
+       @if [ -t 1 ]; then TTY=-it; else TTY=-i; fi; \
+               docker exec $$TTY minirt-valgrind-test bash -c "make re"
+       @./docker-test/test_all.sh
 
 
 # Usage: make container-rebuild (rebuild after code changes)

--- a/docker-test/run.sh
+++ b/docker-test/run.sh
@@ -4,8 +4,18 @@ echo "=== Starting miniRT Docker Container ==="
 echo "Container will start in interactive mode"
 echo ""
 
-# Start the container in interactive mode
-docker-compose -f docker-test/docker-compose.yml up -d
+# Detect available docker-compose command
+if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+else
+    echo "❌ Neither docker-compose nor docker compose is installed." >&2
+    exit 1
+fi
+
+# Start the container in detached mode
+"${COMPOSE_CMD[@]}" -f docker-test/docker-compose.yml up -d
 
 if [ $? -eq 0 ]; then
     echo ""


### PR DESCRIPTION
## Summary
- support both `docker-compose` and `docker compose` in test container runner
- show container start errors and handle non-TTY usage in valgrind test scripts
- make `container-test-all` target resilient to non-interactive environments

## Testing
- `bash -n docker-test/run.sh docker-test/test_all.sh`
- `./docker-test/run.sh` *(fails: Neither docker-compose nor docker compose is installed)*
- `./docker-test/test_all.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12c86a18c832fb7bbfa82b573264f