### PR TITLE
feat: improve docker test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,9 +144,11 @@ container-test-all:
 		echo "Container not running, starting it first..."; \
 		./docker-test/run.sh; \
 	fi
-	@echo "Rebuilding project before testing..."
-	@docker exec -it minirt-valgrind-test bash -c "make re"
-	@./docker-test/test_all.sh
+       @echo "Rebuilding project before testing..."
+       @# Use -it when a TTY is available
+       @if [ -t 1 ]; then TTY=-it; else TTY=-i; fi; \
+               docker exec $$TTY minirt-valgrind-test bash -c "make re"
+       @./docker-test/test_all.sh
 
 
 # Usage: make container-rebuild (rebuild after code changes)

--- a/docker-test/run.sh
+++ b/docker-test/run.sh
@@ -4,8 +4,18 @@ echo "=== Starting miniRT Docker Container ==="
 echo "Container will start in interactive mode"
 echo ""
 
-# Start the container in interactive mode
-docker-compose -f docker-test/docker-compose.yml up -d
+# Detect available docker-compose command
+if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+else
+    echo "❌ Neither docker-compose nor docker compose is installed." >&2
+    exit 1
+fi
+
+# Start the container in detached mode
+"${COMPOSE_CMD[@]}" -f docker-test/docker-compose.yml up -d
 
 if [ $? -eq 0 ]; then
     echo ""

--- a/docker-test/run_valgrind.sh
+++ b/docker-test/run_valgrind.sh
@@ -41,23 +41,29 @@ echo "=== Valgrind Summary ==="
 echo "Full output saved to: valgrind_output.txt"
 echo "Checking for memory errors and leaks..."
 
-if grep -q "definitely lost" valgrind_output.txt; then
+definitely_line=$(grep "definitely lost" valgrind_output.txt)
+definitely_bytes=$(echo "$definitely_line" | awk '{print $4}')
+if [ "$definitely_bytes" != "0" ]; then
     echo "❌ DEFINITE LEAKS DETECTED!"
-    grep "definitely lost" valgrind_output.txt
+    echo "$definitely_line"
 else
     echo "✅ No definite leaks detected"
 fi
 
-if grep -q "indirectly lost" valgrind_output.txt; then
+indirect_line=$(grep "indirectly lost" valgrind_output.txt)
+indirect_bytes=$(echo "$indirect_line" | awk '{print $4}')
+if [ "$indirect_bytes" != "0" ]; then
     echo "⚠️  INDIRECT LEAKS DETECTED!"
-    grep "indirectly lost" valgrind_output.txt
+    echo "$indirect_line"
 else
     echo "✅ No indirect leaks detected"
 fi
 
-if grep -q "possibly lost" valgrind_output.txt; then
+possible_line=$(grep "possibly lost" valgrind_output.txt)
+possible_bytes=$(echo "$possible_line" | awk '{print $4}')
+if [ "$possible_bytes" != "0" ]; then
     echo "⚠️  POSSIBLE LEAKS DETECTED!"
-    grep "possibly lost" valgrind_output.txt
+    echo "$possible_line"
 else
     echo "✅ No possible leaks detected"
 fi
@@ -121,7 +127,7 @@ fi
 
 echo ""
 echo "=== Debug Information ==="
-if grep -q "Invalid read\|Invalid write\|Invalid free\|definitely lost" valgrind_output.txt; then
+if grep -Eq "Invalid read|Invalid write|Invalid free|definitely lost: [1-9]" valgrind_output.txt; then
     echo "For detailed error analysis, run:"
     echo "  ./debug_error.sh valgrind_output.txt"
     echo ""
@@ -136,7 +142,7 @@ if grep -q "Invalid read\|Invalid write\|Invalid free\|definitely lost" valgrind
     if grep -q "Invalid free" valgrind_output.txt; then
         echo "- Invalid free detected in free_scene function"
     fi
-    if grep -q "definitely lost" valgrind_output.txt; then
+    if grep -q "definitely lost: [1-9]" valgrind_output.txt; then
         echo "- Memory leak detected"
     fi
 fi


### PR DESCRIPTION
## Summary
- support both `docker-compose` and `docker compose` in test container runner
- show container start errors and handle non-TTY usage in valgrind test scripts
- make `container-test-all` target resilient to non-interactive environments
- avoid false leak warnings in Valgrind test script by checking leak counts

## Testing
- `bash -n docker-test/run.sh docker-test/test_all.sh docker-test/run_valgrind.sh`
- `shellcheck docker-test/run_valgrind.sh` *(fails: command not found)*
- `./docker-test/run.sh` *(fails: Neither docker-compose nor docker compose is installed)*
- `./docker-test/test_all.sh` *(fails: docker: command not found)*
- `./docker-test/run_valgrind.sh scenes/sample.rt` *(fails: valgrind_output.txt: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c12c86a18c832fb7bbfa82b573264f